### PR TITLE
Version 1.16.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,7 @@ test:
   commands:
     - pip check
     - jupytext --help
-    - test -f ${PREFIX}/share/jupyter/nbextensions/jupytext/index.js                                              # [unix]
     - test -f ${PREFIX}/share/jupyter/labextensions/jupyterlab-jupytext/package.json                              # [unix]
-    - if exist %PREFIX%\\share\\jupyter\\nbextensions\\jupytext\\index.js (exit 0) else (exit 1)                  # [win]
     - if exist %PREFIX%\\share\\jupyter\\labextensions\\jupyterlab-jupytext\\package.json (exit 0) else (exit 1)  # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,28 +13,27 @@ build:
   number: 0
   entry_points:
     - jupytext = jupytext.cli:jupytext
-  skip: true # [py<36 or s390x]
-  script_env:
-    - BUILD_JUPYTERLAB_EXTENSION=1
+    - jupytext-config = jupytext_config.__main__:main
+  skip: true # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:
   host:
     - python
     - pip
-    - python
-    - nodejs 18.16.0
-    - jupyter-packaging
-    - jupyterlab >=3.0,<4.0
     - setuptools
     - wheel
+    - hatchling >=1.5.0
+    - hatch-jupyter-builder >=0.5
+    - jupyterlab >=4
   run:
     - python
     - nbformat
+    - mdit-py-plugins
+    - markdown-it-py >=1.0.0
+    - packaging
     - pyyaml
     - toml
-    - markdown-it-py >=1.0.0
-    - mdit-py-plugins
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupytext" %}
-{% set version = "1.15.2" %}
+{% set version = "1.16.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c9976e24d834e991906c1de55af4b6d512d764f6372aabae45fc1ea72b589173
+  sha256: 68c7b68685e870e80e60fda8286fbd6269e9c74dc1df4316df6fe46eabc94c99
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - python
     - nbformat
     - mdit-py-plugins
-    - markdown-it-py >=1.0.0
+    - markdown-it-py >=1.0
     - packaging
     - pyyaml
     - toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,6 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
     - hatchling >=1.5.0
     - hatch-jupyter-builder >=0.5
     - jupyterlab >=4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - pip
     - hatchling >=1.5.0
     - hatch-jupyter-builder >=0.5
-    - jupyterlab >=4
   run:
     - python
     - nbformat


### PR DESCRIPTION
jupytext 1.16.1

**Destination channel:** defaults

### Links

- [PKG-4159](https://anaconda.atlassian.net/browse/PKG-4159)
- [Upstream repository](https://github.com/mwouts/jupytext/tree/v1.16.1)
- [Upstream changelog/diff](https://github.com/mwouts/jupytext/blob/v1.16.1/CHANGELOG.md)

### Explanation of changes:

- Update version
- Clean up scripts and entry points
- Update dependencies


[PKG-4159]: https://anaconda.atlassian.net/browse/PKG-4159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ