### PR TITLE
jupytext 1.19.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,27 +1,29 @@
 {% set name = "jupytext" %}
-{% set version = "1.18.1" %}
+{% set version = "1.19.3" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5c0962ca8d222db45cbe1848b4805dbbe3ddb957603fc96651b6cd7fd403fafb
+  sha256: 713c3ed4441afe0f31474d28ea2e6b61a268c04c40fd78e5ccfd7f7ac9e9f766
 
 build:
   number: 0
   entry_points:
     - jupytext = jupytext.cli:jupytext
     - jupytext-config = jupytext_config.__main__:main
-  skip: true # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: true # [py<39]
 
 requirements:
   host:
     - python
     - pip
     - hatchling >=1.5.0
+    - hatch-jupyter-builder >=0.5
+    - jupyterlab >=4
   run:
     - python
     - nbformat


### PR DESCRIPTION
jupytext 1.19.3 

**Destination channel:** Defaults

### Links

- [PKG-14805]
- dev_url:        https://github.com/mwouts/jupytext/tree/v1.19.3
- conda_forge:    https://github.com/conda-forge/jupytext-feedstock
- pypi:           https://pypi.org/project/jupytext/1.19.3
- pypi inspector: https://inspector.pypi.io/project/jupytext/1.19.3

### Explanation of changes:

- new version number


[PKG-14805]: https://anaconda.atlassian.net/browse/PKG-14805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ